### PR TITLE
fix: optimize npm wasm artifact with wasm-opt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+env:
+  BINARYEN_VERSION: version_125
+  BINARYEN_X86_64_LINUX_SHA256: 7c3bc16599c8274a04d34a504fe4be2047884f900e0e2da2f6fb9cd667183be4
+
 on:
   push:
     branches: [main]
@@ -45,10 +49,15 @@ jobs:
         with:
           targets: wasm32-wasip1
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-      - name: Build WASM
-        run: cargo build --target wasm32-wasip1 -p esquery-grep --release
-      - name: Copy WASM
-        run: cp target/wasm32-wasip1/release/eg.wasm npm/eg.wasm
+      - name: Install Binaryen
+        run: |
+          archive="binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz"
+          curl -fsSLO "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/${archive}"
+          echo "${BINARYEN_X86_64_LINUX_SHA256}  ${archive}" | sha256sum -c -
+          tar -xzf "${archive}"
+          echo "${PWD}/binaryen-${BINARYEN_VERSION}/bin" >> "${GITHUB_PATH}"
+      - name: Build optimized WASM
+        run: ./scripts/build-wasm.sh
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,5 +1,9 @@
 name: Publish npm
 
+env:
+  BINARYEN_VERSION: version_125
+  BINARYEN_X86_64_LINUX_SHA256: 7c3bc16599c8274a04d34a504fe4be2047884f900e0e2da2f6fb9cd667183be4
+
 on:
   push:
     tags: ["v*"]
@@ -19,11 +23,16 @@ jobs:
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
-      - name: Build WASM
-        run: cargo build --target wasm32-wasip1 -p esquery-grep --release
+      - name: Install Binaryen
+        run: |
+          archive="binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz"
+          curl -fsSLO "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/${archive}"
+          echo "${BINARYEN_X86_64_LINUX_SHA256}  ${archive}" | sha256sum -c -
+          tar -xzf "${archive}"
+          echo "${PWD}/binaryen-${BINARYEN_VERSION}/bin" >> "${GITHUB_PATH}"
 
-      - name: Copy WASM to npm package
-        run: cp target/wasm32-wasip1/release/eg.wasm npm/eg.wasm
+      - name: Build optimized WASM
+        run: ./scripts/build-wasm.sh
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ cargo build --workspace
 cargo test --workspace
 ```
 
+### npm WASM artifact
+
+`npm/eg.wasm` is built with Binaryen's `wasm-opt`, which must be available on `PATH`.
+
+```sh
+./scripts/build-wasm.sh
+```
+
 ## Known Limitations
 
 - TypeScript-specific fields (e.g., `typeAnnotation`) are not traversed because the matcher uses estraverse visitor keys, which only cover standard ESTree node types. TS-specific top-level declarations (e.g., `TSInterfaceDeclaration`) are still found.

--- a/README.md
+++ b/README.md
@@ -97,8 +97,27 @@ cargo test --workspace
 
 `npm/eg.wasm` is built with Binaryen's `wasm-opt`, which must be available on `PATH`.
 
+Local run steps:
+
+1. Install `wasm-opt` from a Binaryen release, or otherwise make it available on `PATH`.
+2. Confirm the command is available with `wasm-opt --version`.
+3. Run the build script from the repository root.
+
+Example using the same Binaryen release as CI:
+
 ```sh
+BINARYEN_VERSION=version_125
+archive="binaryen-${BINARYEN_VERSION}-<platform>.tar.gz"
+curl -fsSLO "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/${archive}"
+tar -xzf "${archive}"
+export PATH="$PWD/binaryen-${BINARYEN_VERSION}/bin:$PATH"
 ./scripts/build-wasm.sh
+```
+
+Smoke test after the build:
+
+```sh
+node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier'
 ```
 
 ## Known Limitations

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+target_wasm="${repo_root}/target/wasm32-wasip1/release/eg.wasm"
+output_wasm="${repo_root}/npm/eg.wasm"
+
+if ! command -v wasm-opt >/dev/null 2>&1; then
+  echo "wasm-opt is required to build the npm package artifact" >&2
+  exit 1
+fi
+
+cd "${repo_root}"
+cargo build --target wasm32-wasip1 -p esquery-grep --release
+wasm-opt -Oz "${target_wasm}" -o "${output_wasm}"
+
+ls -lh "${target_wasm}" "${output_wasm}"


### PR DESCRIPTION
## Summary
- add a shared `scripts/build-wasm.sh` step that builds the WASM binary and runs `wasm-opt -Oz` for the npm artifact
- install the official Binaryen release with checksum verification in CI and npm publish before building `eg.wasm`
- document the local npm WASM artifact build flow in the README, including local setup steps for `wasm-opt`

## Local run
1. Install `wasm-opt` and make it available on `PATH`.
2. Confirm it is available with `wasm-opt --version`.
3. Run `./scripts/build-wasm.sh` from the repository root.

Example using the same Binaryen release as CI:

```sh
BINARYEN_VERSION=version_125
archive="binaryen-${BINARYEN_VERSION}-<platform>.tar.gz"
curl -fsSLO "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/${archive}"
tar -xzf "${archive}"
export PATH="$PWD/binaryen-${BINARYEN_VERSION}/bin:$PATH"
./scripts/build-wasm.sh
```

## Validation
- `cargo test --workspace`
- `bash -n scripts/build-wasm.sh`
- `PATH=<binaryen>/bin:$PATH ./scripts/build-wasm.sh`
- `node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier'`
- `node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'WhileStatement'` (expects exit code `1`)
- `bun npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier'`

## Notes
- confirmed a local size drop from 3.4 MB to 2.6 MB for `eg.wasm`

Related issue: none
