### PR TITLE
fix: parse wasm wrapper args correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,13 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Test Node.js
         run: |
+          node npm/bin/eg.mjs --help | grep 'Usage: eg'
+          node npm/bin/eg.mjs --type ts 'crates/esquery-grep/tests/fixtures/utils.ts' 'Identifier' | grep 'utils.ts'
           node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier' | grep 'greet'
           node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'WhileStatement' && exit 1 || true
       - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
       - name: Test Bun
-        run: bun npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier' | grep 'greet'
+        run: |
+          bun npm/bin/eg.mjs --help | grep 'Usage: eg'
+          bun npm/bin/eg.mjs --type ts 'crates/esquery-grep/tests/fixtures/utils.ts' 'Identifier' | grep 'utils.ts'
+          bun npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier' | grep 'greet'

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -47,7 +47,10 @@ jobs:
         run: npm version --no-git-tag-version "${GITHUB_REF_NAME#v}"
 
       - name: Smoke test
-        run: node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier'
+        run: |
+          node npm/bin/eg.mjs --help | grep 'Usage: eg'
+          node npm/bin/eg.mjs --type ts 'crates/esquery-grep/tests/fixtures/utils.ts' 'Identifier' | grep 'utils.ts'
+          node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier'
 
       - name: Publish
         working-directory: npm

--- a/npm/bin/eg.mjs
+++ b/npm/bin/eg.mjs
@@ -3,13 +3,14 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve, relative, isAbsolute } from "node:path";
+import { parseArgs } from "node:util";
 import { WASI } from "node:wasi";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const wasmPath = resolve(__dirname, "..", "eg.wasm");
 const isBun = typeof Bun !== "undefined";
 
-// Normalize the file pattern argument (argv[2]) for WASI compatibility.
+// Normalize the first positional file pattern argument for WASI compatibility.
 // Other arguments (selector, flags) are passed through as-is.
 // - Bun: preopens {"/":"/"} doubles absolute paths (oven-sh/bun#27724),
 //   so convert to relative from CWD with preopens {".":"."}
@@ -18,12 +19,29 @@ const isBun = typeof Bun !== "undefined";
 const cwd = process.cwd();
 const userArgs = process.argv.slice(2);
 const wasiArgs = [...userArgs];
-if (wasiArgs.length > 0) {
-  const pattern = wasiArgs[0];
+const { tokens } = parseArgs({
+  args: wasiArgs,
+  options: {
+    type: {
+      type: "string",
+      short: "t",
+    },
+  },
+  allowPositionals: true,
+  strict: false,
+  tokens: true,
+});
+const patternArgIndex = tokens.find((token) => token.kind === "positional")?.index ?? -1;
+if (patternArgIndex >= 0) {
+  const pattern = wasiArgs[patternArgIndex];
   if (isBun) {
-    wasiArgs[0] = isAbsolute(pattern) ? relative(cwd, pattern) : pattern;
+    wasiArgs[patternArgIndex] = isAbsolute(pattern)
+      ? relative(cwd, pattern)
+      : pattern;
   } else {
-    wasiArgs[0] = isAbsolute(pattern) ? pattern : resolve(cwd, pattern);
+    wasiArgs[patternArgIndex] = isAbsolute(pattern)
+      ? pattern
+      : resolve(cwd, pattern);
   }
 }
 


### PR DESCRIPTION
## Summary
- fix the npm WASM wrapper so it normalizes only the first positional pattern argument
- use Node's built-in `util.parseArgs()` to preserve `--help`, `--type`, and `--` handling before forwarding args into the WASI guest
- expand CI and publish smoke tests to cover `--help` and leading `--type`

## Validation
- `node npm/bin/eg.mjs --help`
- `node npm/bin/eg.mjs --type ts 'crates/esquery-grep/tests/fixtures/utils.ts' 'Identifier'`
- `node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier'`
- `node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'WhileStatement'` (expects exit code `1`)
- `bun npm/bin/eg.mjs --help`
- `bun npm/bin/eg.mjs --type ts 'crates/esquery-grep/tests/fixtures/utils.ts' 'Identifier'`
- `bun npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier'`

## Notes
- the Node `ExperimentalWarning` still comes from `node:wasi`; this change only fixes argument forwarding

Related issue: none
