### PR TITLE
feat: add version flag to eg CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Test Node.js
         run: |
+          expected_version="$(sed -n 's/^version = "\(.*\)"/\1/p' crates/esquery-grep/Cargo.toml | head -n 1)"
           node npm/bin/eg.mjs --help | grep 'Usage: eg'
+          node npm/bin/eg.mjs --version | grep "^eg ${expected_version}$"
           node npm/bin/eg.mjs --type ts 'crates/esquery-grep/tests/fixtures/utils.ts' 'Identifier' | grep 'utils.ts'
           node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier' | grep 'greet'
           node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'WhileStatement' && exit 1 || true
       - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
       - name: Test Bun
         run: |
+          expected_version="$(sed -n 's/^version = "\(.*\)"/\1/p' crates/esquery-grep/Cargo.toml | head -n 1)"
           bun npm/bin/eg.mjs --help | grep 'Usage: eg'
+          bun npm/bin/eg.mjs --version | grep "^eg ${expected_version}$"
           bun npm/bin/eg.mjs --type ts 'crates/esquery-grep/tests/fixtures/utils.ts' 'Identifier' | grep 'utils.ts'
           bun npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier' | grep 'greet'

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,7 +32,7 @@ jobs:
           echo "${PWD}/binaryen-${BINARYEN_VERSION}/bin" >> "${GITHUB_PATH}"
 
       - name: Build optimized WASM
-        run: ./scripts/build-wasm.sh
+        run: EG_VERSION="${GITHUB_REF_NAME#v}" ./scripts/build-wasm.sh
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
@@ -49,6 +49,7 @@ jobs:
       - name: Smoke test
         run: |
           node npm/bin/eg.mjs --help | grep 'Usage: eg'
+          node npm/bin/eg.mjs --version | grep "^eg ${GITHUB_REF_NAME#v}$"
           node npm/bin/eg.mjs --type ts 'crates/esquery-grep/tests/fixtures/utils.ts' 'Identifier' | grep 'utils.ts'
           node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier'
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ cargo test --workspace
 ### npm WASM artifact
 
 `npm/eg.wasm` is built with Binaryen's `wasm-opt`, which must be available on `PATH`.
+The CLI version defaults to the Rust crate version in `crates/esquery-grep/Cargo.toml`.
+Set `EG_VERSION` if you want the built WASM to report a different version.
 
 Local run steps:
 
@@ -114,9 +116,16 @@ export PATH="$PWD/binaryen-${BINARYEN_VERSION}/bin:$PATH"
 ./scripts/build-wasm.sh
 ```
 
+Override the version embedded in the WASM artifact:
+
+```sh
+EG_VERSION=0.1.5 ./scripts/build-wasm.sh
+```
+
 Smoke test after the build:
 
 ```sh
+node npm/bin/eg.mjs --version
 node npm/bin/eg.mjs 'crates/esquery-grep/tests/fixtures/app.js' 'Identifier'
 ```
 

--- a/crates/esquery-grep/src/main.rs
+++ b/crates/esquery-grep/src/main.rs
@@ -5,8 +5,17 @@ use std::process::ExitCode;
 use clap::Parser;
 use esquery_rs::{JsSourceType, MatchResult};
 
+const CLI_VERSION: &str = match option_env!("EG_VERSION") {
+    Some(version) => version,
+    None => env!("CARGO_PKG_VERSION"),
+};
+
 #[derive(Parser)]
-#[command(name = "eg", about = "grep JS/TS files with ESQuery selectors")]
+#[command(
+    name = "eg",
+    about = "grep JS/TS files with ESQuery selectors",
+    version = CLI_VERSION
+)]
 struct Cli {
     /// File glob pattern (e.g., "src/**/*.ts")
     pattern: String,

--- a/crates/esquery-grep/tests/e2e.rs
+++ b/crates/esquery-grep/tests/e2e.rs
@@ -123,6 +123,14 @@ fn multiline_match_shows_first_line() {
 }
 
 #[test]
+fn version_flag() {
+    eg().arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
 fn skips_unknown_extensions() {
     eg().args([&format!("{}/../Cargo.toml", fixtures()), "*"])
         .assert()

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 target_wasm="${repo_root}/target/wasm32-wasip1/release/eg.wasm"
 output_wasm="${repo_root}/npm/eg.wasm"
+cargo_version="$(
+  sed -n 's/^version = "\(.*\)"/\1/p' "${repo_root}/crates/esquery-grep/Cargo.toml" | head -n 1
+)"
 
 if ! command -v wasm-opt >/dev/null 2>&1; then
   echo "wasm-opt is required to build the npm package artifact" >&2
@@ -11,7 +14,9 @@ if ! command -v wasm-opt >/dev/null 2>&1; then
 fi
 
 cd "${repo_root}"
+export EG_VERSION="${EG_VERSION:-${cargo_version}}"
 cargo build --target wasm32-wasip1 -p esquery-grep --release
 wasm-opt -Oz "${target_wasm}" -o "${output_wasm}"
 
+echo "Built npm/eg.wasm with EG_VERSION=${EG_VERSION}"
 ls -lh "${target_wasm}" "${output_wasm}"


### PR DESCRIPTION
## Summary
- add a real `--version` flag to the Rust CLI and let the WASM build embed `EG_VERSION` when provided
- make the local WASM build fall back to the crate version from `crates/esquery-grep/Cargo.toml`
- verify `--version` in native tests and in Node/Bun smoke tests, while using the release tag version during npm publish

## Validation
- `cargo test --workspace`
- `cargo run -q -p esquery-grep -- --version`
- `bash -n scripts/build-wasm.sh`
- `PATH=<binaryen>/bin:$PATH ./scripts/build-wasm.sh`
- `NODE_OPTIONS=--disable-warning=ExperimentalWarning node npm/bin/eg.mjs --version`
- `PATH=<binaryen>/bin:$PATH EG_VERSION=9.9.9 ./scripts/build-wasm.sh`
- `NODE_OPTIONS=--disable-warning=ExperimentalWarning node npm/bin/eg.mjs --version`
- `bun npm/bin/eg.mjs --version`

## Notes
- the checked-in `npm/package.json` version is still left as-is; the published package version and embedded WASM version are aligned from the same tag value during release

Related issue: none
